### PR TITLE
fix(travis-gh-pages): only deploy after successful build

### DIFF
--- a/travis-deploy-to-gh-pages/.travis.yml
+++ b/travis-deploy-to-gh-pages/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 script:
 - npm run build
 - npm test
-after_script:
+after_success:
 - bash ./scripts/deploy.sh
 env:
   global:


### PR DESCRIPTION
## Summary

Proposed changes:

ensure we only deploy after successful build
shouldn't deploy after failed builds, so change to `after_success`
see https://docs.travis-ci.com/user/customizing-the-build#The-Build-Lifecycle
## Checklist
- [X] The changes only affect or contain one recipe.
- [X] The changes are according to [contribution guidelines](/CONTRIBUTING.md#guidelines).
- [X] The new recipe has an entry in the [recipes index](/README.md#recipes) (only in case of new recipe).
- [X] The changes can be merged into the target branch without conflicts. 
